### PR TITLE
[#95] Fix favicon not always routing.

### DIFF
--- a/void-base/src/main/kotlin/io/voidx/router/util/RequestHandler.kt
+++ b/void-base/src/main/kotlin/io/voidx/router/util/RequestHandler.kt
@@ -23,20 +23,13 @@ internal interface RequestHandler {
     }
 
     /**
-     * Attempts to resolve the incoming [requestDTO] against registered dynamic routes.
+     * Resolve the incoming request against registered dynamic routes and produce a response for the first matching route.
      *
-     * Matching rules:
-     * - Route patterns are tokenized by '/'. Static segments must match exactly.
-     * - Dynamic segments use "{name}" syntax and accept any single path token; the
-     *   captured values are exposed to the page in [DynamicPage._data].
-     * - Optional trailing segments use "{name?}" and may be omitted by the request.
-     * - A single trailing slash at the end of either the request or pattern is ignored.
+     * Dynamic route segments use `{name}` to capture a single path token and `{name?}` for an optional trailing segment; static segments must match exactly and a single trailing slash on either side is ignored. When a match is found the page's `_data`, `request`, and `queries` are populated, the page's "before" middleware is executed, and the page content is returned.
      *
-     * If a route matches, the page's request context and [query] map are populated, the
-     * page BEFORE middleware is executed, and finally [DynamicPage.content] is produced.
-     *
-     * @return a [ResponseDTO] when a dynamic route matches; null otherwise so callers can
-     *         fall back to static routes or 404 handling.
+     * @param requestDTO The incoming request to match.
+     * @param query Map of query parameters to attach to the matched page.
+     * @return A `ResponseDTO` for the matched dynamic route, or `null` if no dynamic route matches.
      */
     fun handleDynamic(
         requestDTO: RequestDTO,

--- a/void-base/src/main/kotlin/io/voidx/router/util/RequestHandler.kt
+++ b/void-base/src/main/kotlin/io/voidx/router/util/RequestHandler.kt
@@ -43,7 +43,6 @@ internal interface RequestHandler {
         query: Map<String, String>,
     ): ResponseDTO? {
         val requestTarget = requestDTO.target
-        if (requestTarget.endsWith("favicon.ico")) return null
         val url = requestTarget.split('/').toMutableList()
         dynamicRoutes.forEach { (target, route) ->
             val dynamics = mutableMapOf<Path, String>()

--- a/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
+++ b/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
@@ -11,6 +11,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 private class SockROS(
@@ -58,6 +59,7 @@ class RequestHandlerOptionalSegmentTests {
         sock.handle(srv, r)
         val out = sock.text()
         // Should hit 404 rather than dynamic route
-        assertTrue(!out.startsWith("HTTP/1.1 404 Not Found\n"), out)
+        assertTrue(out.startsWith("HTTP/1.1 200 OK\n"), out)
+        assertEquals(out.substringAfter("\n\n").trim(), "dyn", out)
     }
 }

--- a/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
+++ b/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
@@ -60,6 +60,6 @@ class RequestHandlerOptionalSegmentTests {
         val out = sock.text()
         // Should hit 404 rather than dynamic route
         assertTrue(out.startsWith("HTTP/1.1 200 OK\n"), out)
-        assertEquals(out.substringAfter("\n\n").trim(), "dyn", out)
+        assertEquals("dyn", out.substringAfter("\n\n").trim(), out)
     }
 }

--- a/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
+++ b/void-base/src/test/kotlin/RequestHandlerOptionalSegmentTests.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 private class SockROS(
-    private val raw: String,
+    raw: String,
 ) : Socket() {
     private val inBytes = ByteArrayInputStream(raw.toByteArray())
     private val outBytes = ByteArrayOutputStream()
@@ -44,7 +44,7 @@ class RequestHandlerOptionalSegmentTests {
     }
 
     @Test
-    fun favicon_is_ignored_by_dynamic_matching_and_yields_404() {
+    fun favicon_is_not_ignored_by_dynamic_matching() {
         val r = router { }
         // A dynamic that would match anything under root if not for favicon bypass
         val p =
@@ -58,6 +58,6 @@ class RequestHandlerOptionalSegmentTests {
         sock.handle(srv, r)
         val out = sock.text()
         // Should hit 404 rather than dynamic route
-        assertTrue(out.startsWith("HTTP/1.1 404 Not Found\n"), out)
+        assertTrue(!out.startsWith("HTTP/1.1 404 Not Found\n"), out)
     }
 }

--- a/void-base/src/test/kotlin/RouterDynamicAndMethodDispatchTests.kt
+++ b/void-base/src/test/kotlin/RouterDynamicAndMethodDispatchTests.kt
@@ -161,8 +161,7 @@ class RouterDynamicAndMethodDispatchTests {
         sock.handle(srv, r)
 
         val raw = sock.text()
-        assertTrue(!raw.startsWith("HTTP/1.1 404 Not Found\n"), raw)
-        // Default 404 page contains this marker in the HTML title
-        assertTrue(!raw.contains("404 | Page Not Found"), raw)
+        assertTrue(raw.startsWith("HTTP/1.1 200 OK\n"), raw)
+        assertEquals("matched", raw.substringAfter("\n\n"))
     }
 }

--- a/void-base/src/test/kotlin/RouterDynamicAndMethodDispatchTests.kt
+++ b/void-base/src/test/kotlin/RouterDynamicAndMethodDispatchTests.kt
@@ -137,7 +137,7 @@ class RouterDynamicAndMethodDispatchTests {
     }
 
     @Test
-    fun dynamic_routes_ignore_favicon_and_fall_back_to_404() {
+    fun dynamic_routes_dont_ignore_favicon() {
         val r = router { }
         // This would normally match any single segment, including "favicon.ico" without the special-case bypass
         r.addRoute(
@@ -161,8 +161,8 @@ class RouterDynamicAndMethodDispatchTests {
         sock.handle(srv, r)
 
         val raw = sock.text()
-        assertTrue(raw.startsWith("HTTP/1.1 404 Not Found\n"), raw)
+        assertTrue(!raw.startsWith("HTTP/1.1 404 Not Found\n"), raw)
         // Default 404 page contains this marker in the HTML title
-        assertTrue(raw.contains("404 | Page Not Found"), raw)
+        assertTrue(!raw.contains("404 | Page Not Found"), raw)
     }
 }


### PR DESCRIPTION
### Description

Please provide a brief summary of the changes made in this pull request.

Favicon was ignored when it came to dynamic routing so we fixed that.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify):

---

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation as needed
- [x] I have checked for code style issues

---

### Related Issues

Closes #95 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Favicon requests are now handled by dynamic routing and can match route patterns instead of automatically returning 404.

* **Documentation**
  * Routing docs expanded to cover dynamic and optional segments, trailing-slash handling, page data population, and middleware execution order.

* **Tests**
  * Test expectations updated to reflect favicon handling by dynamic routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->